### PR TITLE
[Feature/#7] api

### DIFF
--- a/src/apis/issues.ts
+++ b/src/apis/issues.ts
@@ -5,13 +5,13 @@ const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
 const OWNER = 'facebook';
 const REPO = 'react';
 
-export type issueListResponseType =
+export type IssueListResponseType =
   Endpoints['GET /repos/{owner}/{repo}/issues']['response'];
-export type issueResponseType =
+export type IssueResponseType =
   Endpoints['GET /repos/{owner}/{repo}/issues/{issue_number}']['response'];
-export type issueListDataType = issueListResponseType['data'];
-export type issueDataType = issueResponseType['data'];
-type sortType = 'created' | 'updated' | 'comments';
+export type IssueListDataType = IssueListResponseType['data'];
+export type IssueDataType = IssueResponseType['data'];
+type SortType = 'created' | 'updated' | 'comments';
 
 const axiosInstance = axios.create({
   baseURL: 'https://api.github.com',
@@ -23,21 +23,21 @@ const axiosInstance = axios.create({
 
 export class RepositoryAPI {
   private static PATH_ISSUES = `/repos/${OWNER}/${REPO}/issues`;
-  private static QUERY_SORT_TYPE: sortType = 'comments';
+  private static QUERY_SORT_TYPE: SortType = 'comments';
   private static QUERY_PER_PAGE = '15';
 
-  static async getIssueList(page: number): Promise<issueListDataType> {
+  static async getIssueList(page: number): Promise<IssueListDataType> {
     const URI = `${this.PATH_ISSUES}?sort=${this.QUERY_SORT_TYPE}&per_page=${this.QUERY_PER_PAGE}&page=${page}`;
 
-    const result: AxiosResponse<issueListDataType> = await axiosInstance.get(
+    const result: AxiosResponse<IssueListDataType> = await axiosInstance.get(
       URI,
     );
 
     return result.data;
   }
 
-  static async getIssue(issueId: string): Promise<issueDataType> {
-    const response: AxiosResponse<issueDataType> = await axiosInstance.get(
+  static async getIssue(issueId: string): Promise<IssueDataType> {
+    const response: AxiosResponse<IssueDataType> = await axiosInstance.get(
       `${this.PATH_ISSUES}/${issueId}`,
     );
 

--- a/src/apis/issues.ts
+++ b/src/apis/issues.ts
@@ -27,10 +27,15 @@ export class RepositoryAPI {
   private static QUERY_PER_PAGE = '15';
 
   static async getIssueList(page: number): Promise<IssueListDataType> {
-    const URI = `${this.PATH_ISSUES}?sort=${this.QUERY_SORT_TYPE}&per_page=${this.QUERY_PER_PAGE}&page=${page}`;
-
     const result: AxiosResponse<IssueListDataType> = await axiosInstance.get(
-      URI,
+      this.PATH_ISSUES,
+      {
+        params: {
+          sort: this.QUERY_SORT_TYPE,
+          per_page: this.QUERY_PER_PAGE,
+          page: page,
+        },
+      },
     );
 
     return result.data;


### PR DESCRIPTION
## 담당 기능 
* api 구현 

<br/>

## 구현한 기능 
### axios instance
  - baseURL 지정
  - header에 모든 요청 시 공통으로 들어가는 Accept, Authorization(토큰) 지정

### 특정 저장소의 이슈 데이터를 요청하는 api class 
  - private 키워드: path, query의 외부 접근을 막기위해 private 키워드 설정
  - getIssueList: 이슈 목록을 요청하는 메소드
  - getIssue: 단일 이슈를 요청하는 메소드
 
<br/>

## 고민한 부분 
### class 이름 
- 추후 이슈 외 다른 데이터를 요청하는 메소드를 구현해야 할 수도 있어서 class명을 `RepositoryAPI`로 했음 

### sort type
  - 기존의 RepositoryAPI class에서는 쿼리 파라미터 sort의 comments를 private으로 관리하고 있습니다. (`QUERY_SORT_COMMENT = "comments"`)   
  - 과제에서는 comments를 기준으로 정렬하는게 요구사항이지만, 추후 다른 정렬 타입으로 요청할 일이 생길 수 있을 것 같습니다.   
  - 그래서 `QUERY_SORT_COMMENT = "comments"`를 `QUERY_SORT_TYPE: SortType = 'comments'`로 변경했습니다.   
  - 또 sort의 세 가지 타입 외의 다른 문자열이 올 수도 있으니, 기존의 string 타입보다 더 구체적인 리터럴 타입을 지정해 혹시모를 오류를 방지했습니다.

```ts
type SortType = 'created' | 'updated' | 'comments';

export class RepositoryAPI {
  private static QUERY_SORT_TYPE: SortType = 'comments';

  // code...
}
```

### issue type 
- 이슈 데이터의 타입 지정 시 octokit의 타입만 가져와서 사용하고 있는데, 다른 파일에서도 사용할 일이 있었던것 같습니다.
- 그래서 `export` 키워드를 붙여두긴 했는데, 따로 타입만 모아두는 파일을 만들어서 여기서 한번에 관리하면 더 편할것 같습니다. (현재는 api 코드와 함께 있습니다)
```ts
// 다른 곳에서도 공통으로 사용할 것 같은 타입들 
export type IssueListResponseType =
  Endpoints['GET /repos/{owner}/{repo}/issues']['response'];
export type IssueResponseType =
  Endpoints['GET /repos/{owner}/{repo}/issues/{issue_number}']['response'];
export type IssueListDataType = IssueListResponseType['data'];
export type IssueDataType = IssueResponseType['data'];
```

### JS Private fields vs TS `private` keyword
- 현재는 요청 uri의 path, query의 외부 접근을 막기 위해 TS의 private 키워드를 사용해서 보호하고 있습니다. 
- TS의 private 키워드는 컴파일 시 사라지고, 런타임에서 접근 가능합니다([참고](https://www.typescriptlang.org/docs/handbook/2/classes.html#caveats)). Private 키워드를 사용한 목적을 생각해보면 런타임에서도 접근을 제한하는게 좋을 것 같아서 JS의 Private fields(`#`)를 사용해 보호 처리를 하려고 했습니다. 하지만 TS의 target 설정이 ES2015 이상인 경우에만 사용할 수 있다고 합니다(현재 설정은 ES5).
- 그래서 JS Private fields를 사용하려면 TS target 설정을 높여야 하는데, path와 query를 강력하게 보호해야 할 필요는 없는것 같아서 TS의 private 키워드를 사용했습니다. 

<br/>