### PR TITLE
[Feature/#14] IssueList 페이지, useIntersectionObserver 리팩토링

### DIFF
--- a/src/components/common/Error.tsx
+++ b/src/components/common/Error.tsx
@@ -1,0 +1,7 @@
+export default function Error() {
+  return (
+    <div className='bg-gray-200 p-6 rounded-lg absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 shadow-lg'>
+      <h1 className='text-2xl font-bold mb-2'>에러가 발생했습니다.</h1>
+    </div>
+  );
+}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,10 +1,22 @@
 import { useEffect, useRef } from 'react';
 
-export const useIntersectionObserver = ({ callback }: { callback: any }) => {
+interface IntersectionObserverOptionType {
+  threshold?: number | number[];
+  root?: Element | null;
+  rootMargin?: string;
+}
+interface IntersectionObserverType {
+  callback: () => void;
+  option?: IntersectionObserverOptionType;
+}
+
+export const useIntersectionObserver = ({
+  callback,
+  option = {},
+}: IntersectionObserverType) => {
   const ref = useRef(null);
 
   const handleIntersection = (entries: IntersectionObserverEntry[]) => {
-    // 옵저버 콜백함수
     const target = entries[0];
 
     if (target.isIntersecting) {
@@ -15,6 +27,7 @@ export const useIntersectionObserver = ({ callback }: { callback: any }) => {
   useEffect(() => {
     const observer = new IntersectionObserver(handleIntersection, {
       threshold: 0.5,
+      ...option,
     });
 
     if (ref.current) observer.observe(ref.current);

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -35,7 +35,7 @@ export const useIntersectionObserver = ({
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [handleIntersection]);
 
   return ref;
 };

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -3,9 +3,11 @@ import { Link } from 'react-router-dom';
 import { IssueContext } from '../contexts/IssueContext';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+import Error from '../components/common/Error';
 
 export default function IssueList() {
-  const { issues, getInfiniteIssues, isLoading } = useContext(IssueContext);
+  const { issues, getInfiniteIssues, isLoading, isError } =
+    useContext(IssueContext);
 
   const handleIntersection = () => {
     if (!isLoading) {
@@ -47,7 +49,7 @@ export default function IssueList() {
           </div>
         ))}
         {isLoading && <LoadingSpinner />}
-        <li ref={ref}></li>
+        {isError ? <Error /> : <li ref={ref}></li>}
       </ul>
     </div>
   );

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -19,7 +19,7 @@ export default function IssueList() {
     <div className='max-w-xl m-auto'>
       <ul>
         {issues?.map((issue, index) => (
-          <div key={issue.id}>
+          <div key={issue.id + index}>
             <li className='border-solid border-b-2 border-gray-200 '>
               <Link
                 to={`/issue/${issue.id}`}

--- a/src/pages/IssueList.tsx
+++ b/src/pages/IssueList.tsx
@@ -1,12 +1,11 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { IssueContext } from '../contexts/IssueContext';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
 
 export default function IssueList() {
-  const { issues, getInfiniteIssues, isLoading, isError } =
-    useContext(IssueContext);
+  const { issues, getInfiniteIssues, isLoading } = useContext(IssueContext);
 
   const handleIntersection = () => {
     if (!isLoading) {
@@ -15,8 +14,6 @@ export default function IssueList() {
   };
 
   const ref = useIntersectionObserver({ callback: handleIntersection });
-
-  if (isError) return <div>에러</div>;
 
   return (
     <div className='max-w-xl m-auto'>


### PR DESCRIPTION
## 담당 기능
- IssueList 페이지 리팩토링
- useIntersectionObserver 리팩토링

## 구현 내용
### IssueList 페이지 리팩토링

1. div 태그의 key 값 수정
2. IssueList 페이지 isError를 통한 에러 핸들링 제거

### useIntersectionObserver 리팩토링

1. option 파라미터 추가
2. 의존성 배열 추가


## 고민한 부분

### IssueList 페이지 에러 핸들링
IssueList  페이지에서 isError를 통해서 error 처리를 하기보다는 error가 발생한 곳에서 바로 navigate하는 것이 더 효율성이 좋다고 생각함

### useIntersectionObserver 에서 useEffect 의존성 배열 추가
```tsx
// IssueList.tsx
  const handleIntersection = () => {
    if (!isLoading) {
      getInfiniteIssues();
    }
  };

// useIntersectionObserver.ts 
  useEffect(() => {
    const observer = new IntersectionObserver(handleIntersection, {
      threshold: 0.5,
      ...option,
    });

    if (ref.current) observer.observe(ref.current);

    return () => {
      observer.disconnect();
    };
  }, []);
```
handleIntersection에서 조건문 부분은 중복 호출을 방지하기 위한 코드지만 isLoading이 변경되어도 의존성 배열이 비어있어서 함수가 업데이트되지 않음
